### PR TITLE
Update deprecated actions/cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Cache NPM
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-npm
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Cache NPM
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-npm
         with:


### PR DESCRIPTION

# Purpose

This PR automatically updates actions that will stop working on February 1st, 2025.


- `actions/cache@v1`
- `actions/cache@v2`

The new changes to the actions/cache should be seamless and fully backward compatible. You are not expected to change anything in your workflows to use the new service beyond upgrading to the latest releases.

[More information in the announcement](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/).

# Ticket

RAD-39232

# Notifications

Could not identify codeowner. Please tag codeowner in comments (cc @usertesting/effectiveness-and-experience-squad)
